### PR TITLE
Replacing CMake variable with the correct target name variable 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,18 +310,18 @@ if(MCUT_BUILD_AS_SHARED_LIB)
 	# dynamic libs
 	#
 
-	install(TARGETS ${mpn_shared_lib_name}
+	install(TARGETS ${target_name}
 			LIBRARY
-			DESTINATION lib/shared
+			DESTINATION bin/
 			COMPONENT dynamic_libraries)
 else()
 	#
 	# static libs
 	#
 	
-	install(TARGETS ${mpn_static_lib_name}
+	install(TARGETS ${target_name}
 			ARCHIVE
-			DESTINATION lib/static
+			DESTINATION lib/
 			COMPONENT static_libraries)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,7 @@ if(MCUT_BUILD_AS_SHARED_LIB)
 
 	install(TARGETS ${target_name}
 			LIBRARY
-			DESTINATION bin/
+			DESTINATION lib/
 			COMPONENT dynamic_libraries)
 else()
 	#


### PR DESCRIPTION
CMake replacing missing variable with the correct target name variable. Verified to work with CMake version 3.21.

Also moves the static library and shared library install subfolders to the traditional locations for the respective types (/bin/ and /lib/ respectively)

Related to issue #39 